### PR TITLE
warningを抑制する

### DIFF
--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,5 +1,6 @@
 import { ReportHandler } from 'web-vitals';
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     void import('web-vitals').then(


### PR DESCRIPTION
Netlifyへのデプロイ時にbuildに失敗した。
とりあえず以下の警告を抑制してみる。
```
src/reportWebVitals.ts
  Line 3:25:  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
```